### PR TITLE
feat: support watchConnectivityState

### DIFF
--- a/grpc-gcp/src/gcp_channel_factory.ts
+++ b/grpc-gcp/src/gcp_channel_factory.ts
@@ -268,7 +268,6 @@ export class GcpChannelFactory {
       return;
     }
 
-    const startTime = Date.now();
     const connectivityState = this.getConnectivityState(false);
 
     if (connectivityState !== currentState) {
@@ -279,10 +278,9 @@ export class GcpChannelFactory {
     const watchState = async (channelRef: ChannelRef): Promise<void> => {
       const channel = channelRef.getChannel();
       const startingState = channel.getConnectivityState(false);
-      const dl = (deadline as number) - Date.now() - startTime;
 
       await promisify(channel.watchConnectivityState)
-        .call(channel, startingState, dl);
+        .call(channel, startingState, deadline);
 
       const state = this.getConnectivityState(false);
 

--- a/grpc-gcp/test/unit/channel_factory_test.js
+++ b/grpc-gcp/test/unit/channel_factory_test.js
@@ -173,7 +173,13 @@ describe('grpc-gcp channel factory tests', function() {
         return fakeState;
       };
       channel.channelRefs.forEach(channelRef => {
+        channelRef.channel.getConnectivityState = function(connect) {
+          assert.strictEqual(connect, false);
+          return fakeState;
+        };
         channelRef.channel.watchConnectivityState = function(s, d, cb) {
+          assert.strictEqual(s, fakeState);
+          assert.strictEqual(d, 1000);
           channel.getConnectivityState = function() {
             return grpc.connectivityState.IDLE;
           };

--- a/grpc-gcp/test/unit/channel_factory_test.js
+++ b/grpc-gcp/test/unit/channel_factory_test.js
@@ -147,10 +147,25 @@ describe('grpc-gcp channel factory tests', function() {
     afterEach(function() {
       channel.close();
     });
-    it('should throw unimplemented error', function() {
-      assert.throws(() => {
-        channel.watchConnectivityState();
+    it('should throw an error if no channels are available', function(done) {
+      channel.channelRefs = [];
+      channel.watchConnectivityState(0, new Date(), function(err) {
+        assert(err instanceof Error);
+        assert.strictEqual(
+          err.message,
+          'Cannot watch connectivity state because there are no channels.');
+        done();
       });
+    });
+    it('should call channel.watchConnectivityState', function(done) {
+      var fakeState = grpc.connectivityState.READY;
+      var fakeDeadline = new Date();
+      channel.channelRefs[0].watchConnectivityState = function(state, deadline, callback) {
+        assert.strictEqual(state, fakeState);
+        assert.strictEqual(deadline, fakeDeadline);
+        callback();
+      };
+      channel.watchConnectivityState(fakeState, fakeDeadline, done);
     });
   });
   describe('createCall', function() {


### PR DESCRIPTION
Closes #57 

👋 

I have a use case for `watchConnectivityState` in the PubSub client, so I decided to take a crack at it. I was unsure if we should wait for all channels to have the desired state or just one, but `getConnectivityState` looks for at least one, so I basically mirrored that idea.