### PR TITLE
chore: release 0.3.1

### DIFF
--- a/grpc-gcp/package.json
+++ b/grpc-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-gcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Extension for supporting Google Cloud Platform specific features for gRPC.",
   "main": "build/src/index.js",
   "scripts": {
@@ -11,6 +11,7 @@
     "eslint": "./node_modules/.bin/eslint test/integration",
     "check": "gts check",
     "fix": "gts fix",
+    "prepare": "npm run build",
     "prettier": "prettier --write src/*.ts test/**/*.js",
     "coverage": "nyc ./node_modules/.bin/_mocha test/unit test/integration --reporter spec --timeout 600000"
   },


### PR DESCRIPTION
Fixes #71.

The previous release v0.3.0 is empty. This PR has no code changes other than adding `prepare` script to make sure this does not happen again. After this is merged, I'll release v0.3.1.