### PR TITLE
update all dependencies and release v0.3.2

### DIFF
--- a/grpc-gcp/package.json
+++ b/grpc-gcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-gcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Extension for supporting Google Cloud Platform specific features for gRPC.",
   "main": "build/src/index.js",
   "scripts": {
@@ -13,7 +13,8 @@
     "fix": "gts fix",
     "prepare": "npm run build",
     "prettier": "prettier --write src/*.ts test/**/*.js",
-    "coverage": "nyc ./node_modules/.bin/_mocha test/unit test/integration --reporter spec --timeout 600000"
+    "coverage": "nyc ./node_modules/.bin/_mocha test/unit test/integration --reporter spec --timeout 600000",
+    "test": "npm run unit-tests"
   },
   "repository": {
     "type": "git",
@@ -36,24 +37,24 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^0.7.3"
+    "@grpc/grpc-js": "~1.0.2"
   },
   "devDependencies": {
-    "@grpc/proto-loader": "0.4.0",
-    "eslint": "5.15.3",
-    "eslint-config-prettier": "4.1.0",
-    "eslint-plugin-node": "8.0.0",
-    "eslint-plugin-prettier": "3.0.0",
-    "google-auth-library": "3.1.1",
-    "google-gax": "^1.15.1",
-    "google-protobuf": "3.7.0",
+    "@grpc/proto-loader": "^0.5.4",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.1.3",
+    "google-auth-library": "^6.0.0",
+    "google-gax": "^2.3.0",
+    "google-protobuf": "^3.11.4",
     "grpc": "^1.24.2",
     "grpc-tools": "^1.8.1",
-    "gts": "0.9.0",
-    "mocha": "6.0.2",
-    "nyc": "13.3.0",
-    "prettier": "1.16.4",
-    "typescript": "3.3.4000"
+    "gts": "^0.9.0",
+    "mocha": "^7.1.1",
+    "nyc": "^15.0.1",
+    "prettier": "^2.0.5",
+    "typescript": "~3.8.3"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
Just one more release, this time with all dependencies updated. Since Spanner is moving to `@grpc/grpc-js` v1, I want to make sure `grpc-gcp` pulls v1 as well.