### PR TITLE
fix: add a stub implementation of channelz in the channel pool to fix compilation

### DIFF
--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -103,6 +103,10 @@ export function getGcpChannelFactoryClass(
       this.getChannelRef();
     }
 
+    getChannelzRef(): any {
+      throw new Error("channelz is not supported for channel pools.")
+    }
+
     private initMethodToAffinityMap(gcpApiConfig: ApiConfig): void {
       const methodList = gcpApiConfig.method;
       if (methodList) {

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -104,7 +104,7 @@ export function getGcpChannelFactoryClass(
     }
 
     getChannelzRef(): any {
-      throw new Error("channelz is not supported for channel pools.")
+      return this.channelRefs[0].getChannel().getChannelzRef();
     }
 
     private initMethodToAffinityMap(gcpApiConfig: ApiConfig): void {

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -103,7 +103,7 @@ export function getGcpChannelFactoryClass(
       this.getChannelRef();
     }
 
-    getChannelzRef(): any {
+    getChannelzRef() {
       return this.channelRefs[0].getChannel().getChannelzRef();
     }
 

--- a/test/unit/channel_factory_test.js
+++ b/test/unit/channel_factory_test.js
@@ -90,16 +90,6 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
           assert.doesNotThrow(() => {
             new grpcGcp.GcpChannelFactory('hostname', insecureCreds, {key: 5});
           });
-          assert.throws(() => {
-            new grpcGcp.GcpChannelFactory('hostname', insecureCreds, {
-              key: null,
-            });
-          });
-          assert.throws(() => {
-            new grpcGcp.GcpChannelFactory('hostname', insecureCreds, {
-              key: new Date(),
-            });
-          });
         });
         it('should succeed without the new keyword', () => {
           assert.doesNotThrow(() => {


### PR DESCRIPTION
It seems like grpc-js added a new method to the Channel interface for channelz. This breaks compilation against newer versions of grpc-js. Unfortunately there is no sensible implementation for a channelz for a channelpool. This PR simply fixes compilation by throwing an unimplemented error

Also remove stale tests that tested pre-grpc-js behavior