### PR TITLE
Define a generic interface to allow flexibility

### DIFF
--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -24,7 +24,6 @@ import * as protoRoot from './generated/grpc_gcp';
 import {connectivityState} from '@grpc/grpc-js';
 import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import IAffinityConfig = protoRoot.grpc.gcp.IAffinityConfig;
-import {GrpcInterface} from './grpc_interface';
 
 const CLIENT_CHANNEL_ID = 'grpc_gcp.client_channel.id';
 
@@ -49,7 +48,7 @@ export interface GcpChannelFactoryConstructor {
 }
 
 export function getGcpChannelFactoryClass(
-  grpc: GrpcInterface
+  grpc: GrpcModule
 ): GcpChannelFactoryConstructor {
   /**
    * A channel management factory that implements grpc.Channel APIs.

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -24,6 +24,7 @@ import * as protoRoot from './generated/grpc_gcp';
 import {connectivityState} from '@grpc/grpc-js';
 import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import IAffinityConfig = protoRoot.grpc.gcp.IAffinityConfig;
+import {GrpcInterface} from './grpc_interface';
 
 const CLIENT_CHANNEL_ID = 'grpc_gcp.client_channel.id';
 
@@ -48,7 +49,7 @@ export interface GcpChannelFactoryConstructor {
 }
 
 export function getGcpChannelFactoryClass(
-  grpc: GrpcModule
+  grpc: GrpcInterface
 ): GcpChannelFactoryConstructor {
   /**
    * A channel management factory that implements grpc.Channel APIs.

--- a/src/grpc_interface.ts
+++ b/src/grpc_interface.ts
@@ -1,0 +1,6 @@
+export interface GrpcInterface {
+  Channel: any;
+  connectivityState: any;
+  status: any;
+  InterceptingCall: any;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export interface GrpcInterface {
   Channel: any;
   connectivityState: any;
   status: any;
+  InterceptingCall: any;
 };
 
 export = (grpc: GrpcInterface) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,13 @@ import * as protoRoot from './generated/grpc_gcp';
 import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import AffinityConfig = protoRoot.grpc.gcp.AffinityConfig;
 
-type GrpcModule = typeof grpcType;
+export interface GrpcInterface {
+  Channel: any;
+  connectivityState: any;
+  status: any;
+};
 
-export = (grpc: GrpcModule) => {
+export = (grpc: GrpcInterface) => {
   const GcpChannelFactory = getGcpChannelFactoryClass(grpc);
   /**
    * Create ApiConfig proto message from config object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
  *
  */
 import * as grpcType from '@grpc/grpc-js';
+import {GrpcInterface} from './grpc_interface';
 import * as util from 'util';
 
 import {ChannelRef} from './channel_ref';
@@ -27,9 +28,11 @@ import * as protoRoot from './generated/grpc_gcp';
 
 import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import AffinityConfig = protoRoot.grpc.gcp.AffinityConfig;
-import {GrpcInterface} from './grpc_interface';
 
-export = (grpc: GrpcInterface) => {
+type GrpcModule = typeof grpcType;
+
+export = (grpc: GrpcInterface) => setup(grpc as GrpcModule);
+const setup = (grpc: GrpcModule) => {
   const GcpChannelFactory = getGcpChannelFactoryClass(grpc);
   /**
    * Create ApiConfig proto message from config object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,7 @@ import * as protoRoot from './generated/grpc_gcp';
 
 import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import AffinityConfig = protoRoot.grpc.gcp.AffinityConfig;
-
-interface GrpcInterface {
-  Channel: any;
-  connectivityState: any;
-  status: any;
-  InterceptingCall: any;
-};
+import {GrpcInterface} from './grpc_interface';
 
 export = (grpc: GrpcInterface) => {
   const GcpChannelFactory = getGcpChannelFactoryClass(grpc);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import * as protoRoot from './generated/grpc_gcp';
 import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import AffinityConfig = protoRoot.grpc.gcp.AffinityConfig;
 
-export interface GrpcInterface {
+interface GrpcInterface {
   Channel: any;
   connectivityState: any;
   status: any;


### PR DESCRIPTION
This PR will allow code that uses this library to be more flexible in terms of the object passed into the function mentioned in index.ts.
