### PR TITLE
Fix missing runtime dependency on `protobufjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.7.0"
+    "@grpc/grpc-js": "^1.7.0",
+    "protobufjs": "7.4.0"
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.0",


### PR DESCRIPTION
This dependency is used at runtime in the `generated/` files, but it's not explicitly specified. This can break consumption with strict package managers like pnpm, or Yarn PnP.

Fixes #166 