### PR TITLE
chore(affinity): add support for custom affinity key bind and unbind via calloptions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ test/google
 test/googleapis
 src/generated
 build/
+cloudprober/

--- a/cloudprober/grpc_gcp_prober/firestore_probes.js
+++ b/cloudprober/grpc_gcp_prober/firestore_probes.js
@@ -7,7 +7,7 @@
 
 const firestore = require('../google/firestore/v1beta1/firestore_pb.js');
 const _PARENT_RESOURCE =
-    'projects/grpc-prober-testing/databases/(default)/documents';
+  'projects/grpc-prober-testing/databases/(default)/documents';
 
 /**
  * Probes to test session related grpc calls from Spanner client.
@@ -17,19 +17,20 @@ const _PARENT_RESOURCE =
  */
 function documents(client, metrics) {
   return new Promise((resolve, reject) => {
-    var listDocsRequest = new firestore.ListDocumentsRequest();
+    const listDocsRequest = new firestore.ListDocumentsRequest();
     listDocsRequest.setParent(_PARENT_RESOURCE);
-    var start = new Date();
+    const start = new Date();
     client.listDocuments(listDocsRequest, (error, response) => {
       if (error) {
         reject(error);
       } else {
-        var latency = (new Date() - start);
+        const latency = new Date() - start;
         metrics['list_documents_latency_ms'] = latency;
-        var docArray = response.getDocumentsList();
+        const docArray = response.getDocumentsList();
         if (!docArray || !docArray.length) {
-          reject(new Error(
-              'ListDocumentsResponse should have more than 1 document'));
+          reject(
+            new Error('ListDocumentsResponse should have more than 1 document')
+          );
         }
         resolve();
       }
@@ -37,8 +38,7 @@ function documents(client, metrics) {
   });
 }
 
-
 // exports.documents = documents;
 exports.probeFunctions = {
-  'documents': documents
+  documents: documents,
 };

--- a/cloudprober/grpc_gcp_prober/prober.js
+++ b/cloudprober/grpc_gcp_prober/prober.js
@@ -2,8 +2,7 @@
  * @fileoverview Main entrypoint to execute probes for different cloud APIs.
  */
 
-const firestore_grpc =
-    require('../google/firestore/v1beta1/firestore_grpc_pb.js');
+const firestore_grpc = require('../google/firestore/v1beta1/firestore_grpc_pb.js');
 const spanner_grpc = require('../google/spanner/v1/spanner_grpc_pb.js');
 const {GoogleAuth} = require('google-auth-library');
 const grpc = require('grpc');
@@ -16,16 +15,15 @@ const _OAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
 const _FIRESTORE_TARGET = 'firestore.googleapis.com:443';
 const _SPANNER_TARGET = 'spanner.googleapis.com:443';
 
-
 /**
  * Retrieves arguments before executing probes.
  * @return {Object} An object containing all the args parsed in.
  */
 function getArgs() {
-  var parser = new argparse.ArgumentParser({
+  const parser = new argparse.ArgumentParser({
     version: '0.0.1',
     addHelp: true,
-    description: 'Argument parser for grpc gcp prober.'
+    description: 'Argument parser for grpc gcp prober.',
   });
   parser.addArgument('--api', {help: 'foo bar'});
   return parser.parseArgs();
@@ -36,8 +34,8 @@ function getArgs() {
  * @param {string} api The name of the api provider, e.g. "spanner", "firestore".
  */
 function executeProbes(api) {
-  var authFactory = new GoogleAuth();
-  var util = new stackdriver_util.StackdriverUtil(api);
+  const authFactory = new GoogleAuth();
+  const util = new stackdriver_util.StackdriverUtil(api);
 
   authFactory.getApplicationDefault((err, auth) => {
     if (err) {
@@ -45,48 +43,54 @@ function executeProbes(api) {
       return;
     }
     if (auth.createScopedRequired && auth.createScopedRequired()) {
-      var scopes = [_OAUTH_SCOPE];
+      const scopes = [_OAUTH_SCOPE];
       auth = auth.createScoped(scopes);
     }
-    var sslCreds = grpc.credentials.createSsl();
-    var callCreds = grpc.credentials.createFromGoogleCredential(auth);
-    var channelCreds =
-        grpc.credentials.combineChannelCredentials(sslCreds, callCreds);
+    const sslCreds = grpc.credentials.createSsl();
+    const callCreds = grpc.credentials.createFromGoogleCredential(auth);
+    const channelCreds = grpc.credentials.combineChannelCredentials(
+      sslCreds,
+      callCreds
+    );
     if (api === 'firestore') {
-      var client =
-          new firestore_grpc.FirestoreClient(_FIRESTORE_TARGET, channelCreds);
+      var client = new firestore_grpc.FirestoreClient(
+        _FIRESTORE_TARGET,
+        channelCreds
+      );
       var probeFunctions = firestore_probes.probeFunctions;
     } else if (api === 'spanner') {
-      var client =
-          new spanner_grpc.SpannerClient(_SPANNER_TARGET, channelCreds);
+      var client = new spanner_grpc.SpannerClient(
+        _SPANNER_TARGET,
+        channelCreds
+      );
       var probeFunctions = spanner_probes.probeFunctions;
     } else {
       throw new Error('gRPC prober is not implemented for ' + api + ' !');
     }
 
-    var metrics = {};
-    var probeNames = Object.keys(probeFunctions);
-    var promises = probeNames.map((probeName) => {
+    const metrics = {};
+    const probeNames = Object.keys(probeFunctions);
+    const promises = probeNames.map(probeName => {
       probe_function = probeFunctions[probeName];
       return probe_function(client, metrics);
     });
 
     Promise.all(promises)
-        .then(() => {
-          util.setSuccess(true);
-        })
-        .catch((err) => {
-          util.setSuccess(false);
-          util.reportError(err);
-        })
-        .then(() => {
-          util.addMetrics(metrics);
-          util.outputMetrics();
-        });
+      .then(() => {
+        util.setSuccess(true);
+      })
+      .catch(err => {
+        util.setSuccess(false);
+        util.reportError(err);
+      })
+      .then(() => {
+        util.addMetrics(metrics);
+        util.outputMetrics();
+      });
 
     // TODO: if fail, exit probe.
   });
 }
 
-var args = getArgs();
+const args = getArgs();
 executeProbes(args.api);

--- a/cloudprober/grpc_gcp_prober/spanner_probes.js
+++ b/cloudprober/grpc_gcp_prober/spanner_probes.js
@@ -7,7 +7,7 @@
 
 const spanner = require('../google/spanner/v1/spanner_pb.js');
 const _DATABASE =
-    'projects/grpc-prober-testing/instances/weiranf-instance/databases/test-db';
+  'projects/grpc-prober-testing/instances/weiranf-instance/databases/test-db';
 const _TEST_USERNAME = 'test_username';
 const Promise = require('bluebird');
 
@@ -18,18 +18,18 @@ const Promise = require('bluebird');
  * @return {Promise} A promise after a sequence of client calls.
  */
 function sessionManagement(client, metrics) {
-  var sessionName;
+  let sessionName;
 
-  let createSession = () => {
+  const createSession = () => {
     return new Promise((resolve, reject) => {
-      var createSessionRequest = new spanner.CreateSessionRequest();
+      const createSessionRequest = new spanner.CreateSessionRequest();
       createSessionRequest.setDatabase(_DATABASE);
-      var start = new Date();
+      const start = new Date();
       client.createSession(createSessionRequest, (error, session) => {
         if (error) {
           reject(error);
         } else {
-          var latency = (new Date() - start);
+          const latency = new Date() - start;
           metrics['create_session_latency_ms'] = latency;
           sessionName = session.getName();
           resolve();
@@ -38,21 +38,24 @@ function sessionManagement(client, metrics) {
     });
   };
 
-  let getSession = () => {
+  const getSession = () => {
     return new Promise((resolve, reject) => {
-      var getSessionRequest = new spanner.GetSessionRequest();
+      const getSessionRequest = new spanner.GetSessionRequest();
       getSessionRequest.setName(sessionName);
       start = new Date();
       client.getSession(getSessionRequest, (error, sessionResult) => {
         if (error) {
           reject(error);
         } else {
-          var latency = (new Date() - start);
+          const latency = new Date() - start;
           metrics['get_session_latency_ms'] = latency;
           if (sessionResult.getName() != sessionName) {
-            reject(new Error(
+            reject(
+              new Error(
                 'client.getSession has incorrect result: ' +
-                sessionResult.getName()));
+                  sessionResult.getName()
+              )
+            );
           }
           resolve();
         }
@@ -60,16 +63,16 @@ function sessionManagement(client, metrics) {
     });
   };
 
-  let deleteSession = () => {
+  const deleteSession = () => {
     return new Promise((resolve, reject) => {
-      var deleteSessionRequest = new spanner.DeleteSessionRequest();
+      const deleteSessionRequest = new spanner.DeleteSessionRequest();
       deleteSessionRequest.setName(sessionName);
       start = new Date();
-      client.deleteSession(deleteSessionRequest, (error) => {
+      client.deleteSession(deleteSessionRequest, error => {
         if (error) {
           reject(error);
         } else {
-          var latency = (new Date() - start);
+          const latency = new Date() - start;
           metrics['delete_session_latency_ms'] = latency;
           resolve();
         }
@@ -78,16 +81,16 @@ function sessionManagement(client, metrics) {
   };
 
   return createSession()
-      .then(() => {
-        return getSession();
-      })
-      .finally(() => {
-        if (sessionName) {
-          return deleteSession();
-        }
-      });
+    .then(() => {
+      return getSession();
+    })
+    .finally(() => {
+      if (sessionName) {
+        return deleteSession();
+      }
+    });
 }
 
 exports.probeFunctions = {
-  'sessionManagement': sessionManagement
+  sessionManagement: sessionManagement,
 };

--- a/cloudprober/grpc_gcp_prober/stackdriver_util.js
+++ b/cloudprober/grpc_gcp_prober/stackdriver_util.js
@@ -42,7 +42,7 @@ class StackdriverUtil {
       console.log(this.api_ + '_success 0');
     }
 
-    for (var metric_name in this.metrics_) {
+    for (const metric_name in this.metrics_) {
       console.log(metric_name + ' ' + this.metrics_[metric_name]);
     }
   }
@@ -53,8 +53,11 @@ class StackdriverUtil {
   reportError(err) {
     console.error(err);
     this.errClient_.report(
-        'NodeProberFailure: gRPC(v=x.x.x) fails on ' + this.api_ +
-        ' API. Details: ' + err.toString());
+      'NodeProberFailure: gRPC(v=x.x.x) fails on ' +
+        this.api_ +
+        ' API. Details: ' +
+        err.toString()
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && cp -r src/generated build/src/",
     "system-test": "c8 mocha test/integration/*.js --reporter spec --timeout 10000 --grpclib grpc && c8 mocha test/integration/*.js --reporter spec --timeout 10000 --grpclib @grpc/grpc-js",
     "test": "c8 mocha test/unit/*.js --reporter spec",
-    "lint": "gts check src/**/*.ts",
+    "lint": "gts check \"src/**/*.ts\"",
     "fix": "gts fix",
     "prepare": "npm run build"
   },
@@ -36,14 +36,16 @@
     "protobufjs": "7.4.0"
   },
   "devDependencies": {
-    "@grpc/proto-loader": "^0.7.0",
     "@google-cloud/spanner": "^6.0.0",
+    "@grpc/proto-loader": "^0.7.0",
+    "@types/glob": "8.1.0",
+    "@types/node": "^18.19.130",
     "c8": "^7.7.2",
     "google-auth-library": "^8.0.0",
     "google-gax": "^3.0.0",
     "google-protobuf": "^3.17.1",
     "grpc": "^1.24.10",
-    "grpc-tools": "^1.11.1",
+    "grpc-tools": "1.12.0",
     "gts": "^3.1.0",
     "mocha": "^9.2.2",
     "typescript": "^4.3.2"

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -26,6 +26,8 @@ import ApiConfig = protoRoot.grpc.gcp.ApiConfig;
 import IAffinityConfig = protoRoot.grpc.gcp.IAffinityConfig;
 
 const CLIENT_CHANNEL_ID = 'grpc_gcp.client_channel.id';
+const CLEANUP_INTERVAL_MS = 30000; // Sweep every 30 seconds
+const IDLE_TIMEOUT_MS = 180000; // Keys are considered idle if unused for more than 3 minutes
 
 export type GrpcModule = typeof grpcType;
 
@@ -123,7 +125,11 @@ export function getGcpChannelFactoryClass(
         this.addChannel();
       }
 
-      this.cleanupTimer = setInterval(() => this.cleanupIdleKeys(), 30000);
+      // Periodically clean up affinity keys that haven't been accessed for a while to prevent unbounded growth.
+      this.cleanupTimer = setInterval(
+        () => this.cleanupIdleKeys(),
+        CLEANUP_INTERVAL_MS
+      );
       if (this.cleanupTimer.unref) {
         this.cleanupTimer.unref();
       }
@@ -202,7 +208,7 @@ export function getGcpChannelFactoryClass(
         key,
         lastAccessed,
       ] of this.affinityKeyLastAccessed.entries()) {
-        if (now - lastAccessed > 180000) {
+        if (now - lastAccessed > IDLE_TIMEOUT_MS) {
           // if a key is not in used for more than 3 minutes remove its binding
           keysToUnbind.push(key);
         }
@@ -288,6 +294,9 @@ export function getGcpChannelFactoryClass(
       existingChannelRef.affinityCountIncr();
     }
 
+    /**
+     * Checks if an affinity key is already bound to a channel.
+     */
     isBound(affinityKey: string): boolean {
       return this.affinityKeyToChannelRef.has(affinityKey);
     }

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -34,8 +34,9 @@ export interface GcpChannelFactoryInterface extends grpcType.ChannelInterface {
   getAffinityConfig(methodName: string): IAffinityConfig;
   bind(channelRef: ChannelRef, affinityKey: string): void;
   unbind(boundKey?: string): void;
-  shouldRequestDebugHeaders(lastRequested: Date | null) : boolean;
-
+  shouldRequestDebugHeaders(lastRequested: Date | null): boolean;
+  isBound(affinityKey: string): boolean;
+  bindIfUnbound(channelRef: ChannelRef, affinityKey: string): boolean;
 }
 
 export interface GcpChannelFactoryConstructor {
@@ -59,7 +60,9 @@ export function getGcpChannelFactoryClass(
     private maxConcurrentStreamsLowWatermark: number;
     private options: {};
     private methodToAffinity: {[key: string]: IAffinityConfig} = {};
-    private affinityKeyToChannelRef: {[affinityKey: string]: ChannelRef} = {};
+    private affinityKeyToChannelRef = new Map<string, ChannelRef>();
+    private affinityKeyLastAccessed = new Map<string, number>();
+    private cleanupTimer: ReturnType<typeof setInterval>;
     private channelRefs: ChannelRef[] = [];
     private target: string;
     private credentials: grpcType.ChannelCredentials;
@@ -100,9 +103,12 @@ export function getGcpChannelFactoryClass(
           }
 
           if (this.maxSize < this.minSize) {
-            throw new Error('Invalid channelPool config: minSize must <= maxSize')
+            throw new Error(
+              'Invalid channelPool config: minSize must <= maxSize'
+            );
           }
-          this.debugHeaderIntervalSecs = channelPool.debugHeaderIntervalSecs || 0;
+          this.debugHeaderIntervalSecs =
+            channelPool.debugHeaderIntervalSecs || 0;
         }
         this.initMethodToAffinityMap(gcpApiConfig);
       }
@@ -115,6 +121,11 @@ export function getGcpChannelFactoryClass(
       // Create initial channels
       for (let i = 0; i < this.minSize; i++) {
         this.addChannel();
+      }
+
+      this.cleanupTimer = setInterval(() => this.cleanupIdleKeys(), 30000);
+      if (this.cleanupTimer.unref) {
+        this.cleanupTimer.unref();
       }
     }
 
@@ -146,24 +157,31 @@ export function getGcpChannelFactoryClass(
      * @return Wrapper containing the grpc channel.
      */
     getChannelRef(affinityKey?: string): ChannelRef {
-      if (affinityKey && this.affinityKeyToChannelRef[affinityKey]) {
+      if (affinityKey) {
+        this.affinityKeyLastAccessed.set(affinityKey, Date.now());
+      }
+      if (affinityKey && this.affinityKeyToChannelRef.has(affinityKey)) {
         // Chose an bound channel if affinityKey is specified.
-        return this.affinityKeyToChannelRef[affinityKey];
+        return this.affinityKeyToChannelRef.get(affinityKey)!;
       }
 
-      // Sort channel refs by active streams count.
-      this.channelRefs.sort((ref1, ref2) => {
-        return ref1.getActiveStreamsCount() - ref2.getActiveStreamsCount();
-      });
+      // Find the channelRef that has the least busy channel.
+      let minRef = this.channelRefs[0];
+      for (let i = 1; i < this.channelRefs.length; i++) {
+        if (
+          this.channelRefs[i].getActiveStreamsCount() <
+          minRef.getActiveStreamsCount()
+        ) {
+          minRef = this.channelRefs[i];
+        }
+      }
 
       const size = this.channelRefs.length;
-      // Chose the channelRef that has the least busy channel.
       if (
         size > 0 &&
-        this.channelRefs[0].getActiveStreamsCount() <
-          this.maxConcurrentStreamsLowWatermark
+        minRef.getActiveStreamsCount() < this.maxConcurrentStreamsLowWatermark
       ) {
-        return this.channelRefs[0];
+        return minRef;
       }
 
       // If all existing channels are busy, and channel pool still has capacity,
@@ -171,24 +189,41 @@ export function getGcpChannelFactoryClass(
       if (size < this.maxSize) {
         return this.addChannel();
       } else {
-        return this.channelRefs[0];
+        return minRef;
       }
+    }
+
+    private cleanupIdleKeys() {
+      const now = Date.now();
+      // Store keys to unbind in an array before iterating to avoid
+      // modifying the Map while we are actively iterating over its entries.
+      const keysToUnbind: string[] = [];
+      for (const [
+        key,
+        lastAccessed,
+      ] of this.affinityKeyLastAccessed.entries()) {
+        if (now - lastAccessed > 180000) {
+          // if a key is not in used for more than 3 minutes remove its binding
+          keysToUnbind.push(key);
+        }
+      }
+      keysToUnbind.forEach(key => this.unbind(key));
     }
 
     /**
      * Create a new channel and add it to the pool.
      * @private
      */
-    private addChannel() : ChannelRef {
+    private addChannel(): ChannelRef {
       const size = this.channelRefs.length;
       const channelOptions = Object.assign(
-          {[CLIENT_CHANNEL_ID]: size},
-          this.options
+        {[CLIENT_CHANNEL_ID]: size},
+        this.options
       );
       const grpcChannel = new grpc.Channel(
-          this.target,
-          this.credentials,
-          channelOptions
+        this.target,
+        this.credentials,
+        channelOptions
       );
       const channelRef = new ChannelRef(grpcChannel, size);
       this.channelRefs.push(channelRef);
@@ -201,23 +236,22 @@ export function getGcpChannelFactoryClass(
     }
 
     private setupDebugHeadersOnChannelTransition(channel: ChannelRef) {
-      const self = this;
-
       if (channel.isClosed()) {
         return;
       }
 
-      let currentState = channel.getChannel().getConnectivityState(false);
-      if (currentState == connectivityState.SHUTDOWN) {
+      const currentState = channel.getChannel().getConnectivityState(false);
+      if (currentState === connectivityState.SHUTDOWN) {
         return;
       }
 
-      channel.getChannel().watchConnectivityState(currentState, Infinity, (e) => {
-        channel.forceDebugHeadersOnNextRequest();
-        self.setupDebugHeadersOnChannelTransition(channel);
-      });
+      channel
+        .getChannel()
+        .watchConnectivityState(currentState, Infinity, () => {
+          channel.forceDebugHeadersOnNextRequest();
+          this.setupDebugHeadersOnChannelTransition(channel);
+        });
     }
-
 
     /**
      * Get AffinityConfig associated with a certain method.
@@ -227,12 +261,15 @@ export function getGcpChannelFactoryClass(
       return this.methodToAffinity[methodName];
     }
 
-    shouldRequestDebugHeaders(lastRequested: Date | null) : boolean {
+    shouldRequestDebugHeaders(lastRequested: Date | null): boolean {
       if (this.debugHeaderIntervalSecs < 0) return true;
-      else if (this.debugHeaderIntervalSecs == 0) return false;
+      else if (this.debugHeaderIntervalSecs === 0) return false;
       else if (!lastRequested) return true;
 
-      return new Date().getTime() - lastRequested.getTime() > this.debugHeaderIntervalSecs * 1000;
+      return (
+        new Date().getTime() - lastRequested.getTime() >
+        this.debugHeaderIntervalSecs * 1000
+      );
     }
 
     /**
@@ -242,11 +279,36 @@ export function getGcpChannelFactoryClass(
      */
     bind(channelRef: ChannelRef, affinityKey: string): void {
       if (!affinityKey || !channelRef) return;
-      const existingChannelRef = this.affinityKeyToChannelRef[affinityKey];
+      let existingChannelRef = this.affinityKeyToChannelRef.get(affinityKey);
       if (!existingChannelRef) {
-        this.affinityKeyToChannelRef[affinityKey] = channelRef;
+        this.affinityKeyToChannelRef.set(affinityKey, channelRef);
+        existingChannelRef = channelRef;
       }
-      this.affinityKeyToChannelRef[affinityKey].affinityCountIncr();
+      this.affinityKeyLastAccessed.set(affinityKey, Date.now());
+      existingChannelRef.affinityCountIncr();
+    }
+
+    isBound(affinityKey: string): boolean {
+      return this.affinityKeyToChannelRef.has(affinityKey);
+    }
+
+    /**
+     * Binds an affinity key to a channel if it is not already bound.
+     * This ensures atomic binding on the first request of a transaction,
+     * preventing race conditions when multiple concurrent requests start.
+     *
+     * @param channelRef The channel to bind to.
+     * @param affinityKey The unique key for the transaction.
+     */
+    bindIfUnbound(channelRef: ChannelRef, affinityKey: string): boolean {
+      if (!affinityKey || !channelRef) return false;
+      if (!this.affinityKeyToChannelRef.has(affinityKey)) {
+        this.affinityKeyToChannelRef.set(affinityKey, channelRef);
+        this.affinityKeyLastAccessed.set(affinityKey, Date.now());
+        channelRef.affinityCountIncr();
+        return true;
+      }
+      return false;
     }
 
     /**
@@ -255,11 +317,12 @@ export function getGcpChannelFactoryClass(
      */
     unbind(boundKey?: string): void {
       if (!boundKey) return;
-      const boundChannelRef = this.affinityKeyToChannelRef[boundKey];
+      const boundChannelRef = this.affinityKeyToChannelRef.get(boundKey);
       if (boundChannelRef) {
         boundChannelRef.affinityCountDecr();
         if (boundChannelRef.getAffinityCount() <= 0) {
-          delete this.affinityKeyToChannelRef[boundKey];
+          this.affinityKeyToChannelRef.delete(boundKey);
+          this.affinityKeyLastAccessed.delete(boundKey);
         }
       }
     }
@@ -268,6 +331,9 @@ export function getGcpChannelFactoryClass(
      * Close all channels in the channel pool.
      */
     close(): void {
+      if (this.cleanupTimer) {
+        clearInterval(this.cleanupTimer);
+      }
       this.channelRefs.forEach(ref => {
         ref.close();
       });

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -163,7 +163,7 @@ export function getGcpChannelFactoryClass(
      * @return Wrapper containing the grpc channel.
      */
     getChannelRef(affinityKey?: string): ChannelRef {
-      if (affinityKey) {
+      if (affinityKey && this.affinityKeyLastAccessed.has(affinityKey)) {
         this.affinityKeyLastAccessed.set(affinityKey, Date.now());
       }
       if (affinityKey && this.affinityKeyToChannelRef.has(affinityKey)) {
@@ -290,7 +290,8 @@ export function getGcpChannelFactoryClass(
         this.affinityKeyToChannelRef.set(affinityKey, channelRef);
         existingChannelRef = channelRef;
       }
-      this.affinityKeyLastAccessed.set(affinityKey, Date.now());
+      // We explicitly do NOT add regular session keys to affinityKeyLastAccessed
+      // to ensure they are not cleaned up by the 3-minute TTL idle sweep.
       existingChannelRef.affinityCountIncr();
     }
 

--- a/src/gcp_channel_factory.ts
+++ b/src/gcp_channel_factory.ts
@@ -330,7 +330,14 @@ export function getGcpChannelFactoryClass(
       const boundChannelRef = this.affinityKeyToChannelRef.get(boundKey);
       if (boundChannelRef) {
         boundChannelRef.affinityCountDecr();
-        if (boundChannelRef.getAffinityCount() <= 0) {
+        // SAFEGUARD: If it's a custom multiplexed transaction key (which exists in affinityKeyLastAccessed),
+        // we force delete it to prevent memory leaks, because custom keys are ephemeral.
+        // For legacy keys (regular Spanner sessions), we preserve the old behavior
+        // which waits for the entire channel's affinityCount to hit 0 before deleting.
+        if (
+          this.affinityKeyLastAccessed.has(boundKey) ||
+          boundChannelRef.getAffinityCount() <= 0
+        ) {
           this.affinityKeyToChannelRef.delete(boundKey);
           this.affinityKeyLastAccessed.delete(boundKey);
         }

--- a/src/grpc_interface.ts
+++ b/src/grpc_interface.ts
@@ -1,6 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export interface GrpcInterface {
   Channel: any;
   connectivityState: any;
   status: any;
   InterceptingCall: any;
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,7 @@ const setup = (grpc: GrpcModule) => {
    * @param channelFactory The channel management factory.
    * @param path Method path.
    * @param argument The request arguments object.
+   * @param overrideAffinityKey Optional affinity key provided in CallOptions.
    * @return Result containing bound affinity key and the chosen channel ref
    * object.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,9 @@ const setup = (grpc: GrpcModule) => {
               if (boundKey && affinityConfig) {
                 if (
                   (callOptions as any).unbind === true ||
-                  status.code === grpc.status.ABORTED
+                  (affinityKeyFromCallOptions &&
+                    (status.code === grpc.status.ABORTED ||
+                      status.code === grpc.status.CANCELLED))
                 ) {
                   channelFactory.unbind(boundKey);
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ const setup = (grpc: GrpcModule) => {
   /**
    * Handle channel affinity and pick a channel before call starts.
    * @param channelFactory The channel management factory.
-   * @param path Method path.
+   * @param affinityConfig Affinity configuration object.
    * @param argument The request arguments object.
    * @param overrideAffinityKey Optional affinity key provided in CallOptions.
    * @return Result containing bound affinity key and the chosen channel ref
@@ -256,7 +256,7 @@ const setup = (grpc: GrpcModule) => {
    * Handle channel affinity and streams count after call is done.
    * @param channelFactory The channel management factory.
    * @param channelRef ChannelRef instance that contains a real grpc channel.
-   * @param path Method path.
+   * @param affinityConfig Affinity configuration object.
    * @param boundKey Affinity key bound to a channel.
    * @param responseMsg Response proto message.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ const setup = (grpc: GrpcModule) => {
 
     const preProcessResult = preProcess(
       channelFactory,
-      path,
+      affinityConfig,
       argument,
       affinityKeyFromCallOptions
     );
@@ -145,7 +145,7 @@ const setup = (grpc: GrpcModule) => {
                 postProcess(
                   channelFactory,
                   channelRef,
-                  path,
+                  affinityConfig,
                   boundKey,
                   firstMessage
                 );
@@ -220,12 +220,12 @@ const setup = (grpc: GrpcModule) => {
    */
   function preProcess(
     channelFactory: GcpChannelFactoryInterface,
-    path: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    affinityConfig?: any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     argument?: any,
     overrideAffinityKey?: string
   ): {boundKey: string | undefined; channelRef: ChannelRef} {
-    const affinityConfig = channelFactory.getAffinityConfig(path);
     let boundKey = overrideAffinityKey;
     if (!boundKey && argument && affinityConfig) {
       const command = affinityConfig.command;
@@ -263,13 +263,13 @@ const setup = (grpc: GrpcModule) => {
   function postProcess(
     channelFactory: GcpChannelFactoryInterface,
     channelRef: ChannelRef,
-    path: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    affinityConfig?: any,
     boundKey?: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     responseMsg?: any
   ) {
     if (!channelFactory || !responseMsg) return;
-    const affinityConfig = channelFactory.getAffinityConfig(path);
     if (affinityConfig && affinityConfig.command) {
       const command = affinityConfig.command;
       if (command === AffinityConfig.Command.BIND) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,10 @@ const setup = (grpc: GrpcModule) => {
   function gcpCallInvocationTransformer<RequestType, ResponseType>(
     callProperties: grpcType.CallProperties<RequestType, ResponseType>
   ): grpcType.CallProperties<RequestType, ResponseType> {
-    if (!callProperties.channel || !(callProperties.channel instanceof GcpChannelFactory)) {
+    if (
+      !callProperties.channel ||
+      !(callProperties.channel instanceof GcpChannelFactory)
+    ) {
       // The gcpCallInvocationTransformer needs to use gcp channel factory.
       return callProperties;
     }
@@ -85,7 +88,22 @@ const setup = (grpc: GrpcModule) => {
     const callOptions = callProperties.callOptions;
     const callback = callProperties.callback;
 
-    const preProcessResult = preProcess(channelFactory, path, argument);
+    const affinityConfig = channelFactory.getAffinityConfig(path);
+    let affinityKeyFromCallOptions: string | undefined;
+
+    // Check if CallOptions contains the affinity key
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (affinityConfig && (callOptions as any).affinityKey) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      affinityKeyFromCallOptions = (callOptions as any).affinityKey;
+    }
+
+    const preProcessResult = preProcess(
+      channelFactory,
+      path,
+      argument,
+      affinityKeyFromCallOptions
+    );
     const channelRef = preProcessResult.channelRef;
 
     const boundKey = preProcessResult.boundKey;
@@ -120,6 +138,9 @@ const setup = (grpc: GrpcModule) => {
               status: grpcType.StatusObject,
               next: Function
             ) => {
+              // Always decrement stream count on status receive (stream closed)
+              channelRef.activeStreamsCountDecr();
+
               if (status.code === grpc.status.OK) {
                 postProcess(
                   channelFactory,
@@ -128,6 +149,19 @@ const setup = (grpc: GrpcModule) => {
                   boundKey,
                   firstMessage
                 );
+              }
+
+              // Check if CallOptions contains the explicit unbind signal
+              // or if the stream was aborted, which automatically invalidates
+              // the current affinity context.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              if (boundKey && affinityConfig) {
+                if (
+                  (callOptions as any).unbind === true ||
+                  status.code === grpc.status.ABORTED
+                ) {
+                  channelFactory.unbind(boundKey);
+                }
               }
               next(status);
             },
@@ -155,7 +189,11 @@ const setup = (grpc: GrpcModule) => {
       : [];
     newCallOptions.interceptors = interceptors.concat([postProcessInterceptor]);
 
-    if (channelFactory.shouldRequestDebugHeaders(channelRef.getDebugHeadersRequestedAt())) {
+    if (
+      channelFactory.shouldRequestDebugHeaders(
+        channelRef.getDebugHeadersRequestedAt()
+      )
+    ) {
       metadata.set('x-return-encrypted-headers', 'all_response');
       channelRef.notifyDebugHeadersRequested();
     }
@@ -183,11 +221,12 @@ const setup = (grpc: GrpcModule) => {
     channelFactory: GcpChannelFactoryInterface,
     path: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    argument?: any
+    argument?: any,
+    overrideAffinityKey?: string
   ): {boundKey: string | undefined; channelRef: ChannelRef} {
     const affinityConfig = channelFactory.getAffinityConfig(path);
-    let boundKey;
-    if (argument && affinityConfig) {
+    let boundKey = overrideAffinityKey;
+    if (!boundKey && argument && affinityConfig) {
       const command = affinityConfig.command;
       if (
         command === AffinityConfig.Command.BOUND ||
@@ -201,6 +240,11 @@ const setup = (grpc: GrpcModule) => {
     }
     const channelRef = channelFactory.getChannelRef(boundKey);
     channelRef.activeStreamsCountIncr();
+
+    if (overrideAffinityKey) {
+      channelFactory.bindIfUnbound(channelRef, overrideAffinityKey);
+    }
+
     return {
       boundKey,
       channelRef,
@@ -237,7 +281,6 @@ const setup = (grpc: GrpcModule) => {
         channelFactory.unbind(boundKey);
       }
     }
-    channelRef.activeStreamsCountDecr();
   }
 
   /**

--- a/test/integration/local_service_test.js
+++ b/test/integration/local_service_test.js
@@ -415,6 +415,21 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
             });
           });
         });
+        it('should automatically unbind when call is cancelled programmatically', done => {
+          const affinityKey = 'custom-key-cancel';
+          client.unary({}, {affinityKey}, err => {
+            assert.ifError(err);
+            assert.strictEqual(pool.isBound(affinityKey), true);
+            const metadata = new grpc.Metadata();
+            const call = client.unary({}, metadata, {affinityKey}, err2 => {
+              assert.ok(err2);
+              assert.strictEqual(err2.code, grpc.status.CANCELLED);
+              assert.strictEqual(pool.isBound(affinityKey), false);
+              done();
+            });
+            call.cancel();
+          });
+        });
       });
     });
   });

--- a/test/integration/local_service_test.js
+++ b/test/integration/local_service_test.js
@@ -346,7 +346,7 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
             },
             method: [
               {
-                name: ['/TestService/unary'],
+                name: ['/TestService/Unary'],
                 affinity: {
                   command: 'PENDING',
                   affinityKey: 'ignored',
@@ -354,12 +354,21 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
               },
             ],
           });
+          const options = {gcpApiConfig};
+          options.channelOverride = grpcGcp.gcpChannelFactoryOverride(
+            'localhost:' + port,
+            grpc.credentials.createInsecure(),
+            options
+          );
+          options.callInvocationTransformer =
+            grpcGcp.gcpCallInvocationTransformer;
+
           client = new Client(
             'localhost:' + port,
             grpc.credentials.createInsecure(),
-            {gcpApiConfig}
+            options
           );
-          pool = client.getChannel();
+          pool = options.channelOverride;
         });
         afterEach(() => {
           client.close();
@@ -398,7 +407,7 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
             // Force ABORTED (code 10) error via metadata
             const metadata = new grpc.Metadata();
             metadata.set('force-error-code', '10');
-            client.unary({}, {affinityKey, metadata}, err2 => {
+            client.unary({}, metadata, {affinityKey}, err2 => {
               assert.ok(err2);
               assert.strictEqual(err2.code, 10); // Verify it aborted
               assert.strictEqual(pool.isBound(affinityKey), false);

--- a/test/integration/local_service_test.js
+++ b/test/integration/local_service_test.js
@@ -15,29 +15,22 @@
  * limitations under the License.
  *
  */
-
 /**
  * @fileoverview Integration tests for spanner grpc requests.
  */
-
 'use strict';
-
 const protoLoader = require('@grpc/proto-loader');
 const assert = require('assert');
 const getGrpcGcpObjects = require('../../build/src');
-const { promisify } = require('util')
-
+const {promisify} = require('util');
 const PROTO_PATH = __dirname + '/../../protos/test_service.proto';
 const packageDef = protoLoader.loadSync(PROTO_PATH);
-
 for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
   describe('Using ' + grpcLibName, () => {
     const grpc = require(grpcLibName);
     const grpcGcp = getGrpcGcpObjects(grpc);
-
     const server_insecure_creds = grpc.ServerCredentials.createInsecure();
     const Client = grpc.loadPackageDefinition(packageDef).TestService;
-
     const initApiConfig = function () {
       return grpcGcp.createGcpApiConfig({
         channelPool: {
@@ -46,7 +39,6 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
         },
       });
     };
-
     describe('Local service integration tests', () => {
       let server;
       let port;
@@ -57,7 +49,13 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
         server.addService(Client.service, {
           unary: function (call, cb) {
             call.sendMetadata(call.metadata);
-            cb(null, {});
+            const forceErrorCode = call.metadata.get('force-error-code');
+            if (forceErrorCode && forceErrorCode.length > 0) {
+              const code = parseInt(forceErrorCode[0]);
+              cb({code, details: 'Forced error'});
+            } else {
+              cb(null, {});
+            }
           },
           clientStream: function (stream, cb) {
             stream.on('data', data => {});
@@ -94,7 +92,6 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
       after(() => {
         server.forceShutdown();
       });
-
       describe('Different channel options', () => {
         it('no api config', done => {
           const channelOptions = {
@@ -129,7 +126,6 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
           done();
         });
       });
-
       // describe('Debug headers', () => {
       //   let client;
       //   beforeEach(() => {
@@ -144,7 +140,6 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
       //         },
       //       }),
       //     };
-
       //     client = new Client(
       //         'localhost:' + port,
       //         grpc.credentials.createInsecure(),
@@ -158,23 +153,18 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
       //     function makeCallAndReturnMeta() {
       //       return new Promise((resolve, reject) => {
       //         let lastMeta = null;
-
       //         const call = client.unary({}, new grpc.Metadata(), (err, data) => {
       //           if (err) reject(err);
       //           else resolve(lastMeta);
       //         });
-
       //         call.on('metadata', meta => lastMeta = meta);
       //       });
       //     }
       //     let m1 = await makeCallAndReturnMeta();
       //     assert.deepStrictEqual(m1.get('x-return-encrypted-headers'), ['all_response']);
-
       //     let m2 = await makeCallAndReturnMeta();
       //     assert.deepStrictEqual(m2.get('x-return-encrypted-headers'), []);
-
       //     await promisify(setTimeout)(1100);
-
       //     let m3 = await makeCallAndReturnMeta();
       //     assert.deepStrictEqual(m3.get('x-return-encrypted-headers'), ['all_response']);
       //   });
@@ -188,12 +178,9 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
       //     }
       //     let m1 = await makeCallAndReturnMeta();
       //     assert.deepStrictEqual(m1.get('x-return-encrypted-headers'), ['all_response']);
-
       //     let m2 = await makeCallAndReturnMeta();
       //     assert.deepStrictEqual(m2.get('x-return-encrypted-headers'), []);
-
       //     await promisify(setTimeout)(1100);
-
       //     let m3 = await makeCallAndReturnMeta();
       //     assert.deepStrictEqual(m3.get('x-return-encrypted-headers'), ['all_response']);
       //   });
@@ -208,13 +195,11 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
             callInvocationTransformer: grpcGcp.gcpCallInvocationTransformer,
             gcpApiConfig: apiConfig,
           };
-
           client = new Client(
             'localhost:' + port,
             grpc.credentials.createInsecure(),
             channelOptions
           );
-
           metadata = new grpc.Metadata();
           metadata.set('key', 'value');
         });
@@ -346,6 +331,78 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
                 done();
               });
               call.end();
+            });
+          });
+        });
+      });
+
+      describe('Custom Affinity via CallOptions', () => {
+        let client;
+        let pool;
+        beforeEach(() => {
+          const gcpApiConfig = grpcGcp.createGcpApiConfig({
+            channelPool: {
+              maxSize: 3,
+            },
+            method: [
+              {
+                name: ['/TestService/unary'],
+                affinity: {
+                  command: 'PENDING',
+                  affinityKey: 'ignored',
+                },
+              },
+            ],
+          });
+          client = new Client(
+            'localhost:' + port,
+            grpc.credentials.createInsecure(),
+            {gcpApiConfig}
+          );
+          pool = client.getChannel();
+        });
+        afterEach(() => {
+          client.close();
+        });
+        it('should route requests with the same custom affinityKey to the same channel', done => {
+          const affinityKey = 'custom-key-123';
+          client.unary({}, {affinityKey}, (err, response) => {
+            assert.ifError(err);
+            assert.strictEqual(pool.isBound(affinityKey), true);
+            const boundChannel = pool.getChannelRef(affinityKey);
+            client.unary({}, {affinityKey}, (err2, response2) => {
+              assert.ifError(err2);
+              const secondChannel = pool.getChannelRef(affinityKey);
+              assert.strictEqual(secondChannel, boundChannel);
+              done();
+            });
+          });
+        });
+        it('should unbind the channel when unbind: true is passed', done => {
+          const affinityKey = 'custom-key-456';
+          client.unary({}, {affinityKey}, err => {
+            assert.ifError(err);
+            assert.strictEqual(pool.isBound(affinityKey), true);
+            client.unary({}, {affinityKey, unbind: true}, err2 => {
+              assert.ifError(err2);
+              assert.strictEqual(pool.isBound(affinityKey), false);
+              done();
+            });
+          });
+        });
+        it('should automatically unbind on ABORTED error', done => {
+          const affinityKey = 'custom-key-789';
+          client.unary({}, {affinityKey}, err => {
+            assert.ifError(err);
+            assert.strictEqual(pool.isBound(affinityKey), true);
+            // Force ABORTED (code 10) error via metadata
+            const metadata = new grpc.Metadata();
+            metadata.set('force-error-code', '10');
+            client.unary({}, {affinityKey, metadata}, err2 => {
+              assert.ok(err2);
+              assert.strictEqual(err2.code, 10); // Verify it aborted
+              assert.strictEqual(pool.isBound(affinityKey), false);
+              done();
             });
           });
         });

--- a/test/integration/spanner_test.js
+++ b/test/integration/spanner_test.js
@@ -39,8 +39,7 @@ const _INSTANCE_ID =
   'test-instance-' + Math.floor(Math.random() * _MAX_RAND_ID);
 const _DATABASE_ID = 'test-db-' + Math.floor(Math.random() * _MAX_RAND_ID);
 const _TABLE_NAME = 'storage';
-const _DATABASE =
-  `projects/${_PROJECT_ID}/instances/${_INSTANCE_ID}/databases/${_DATABASE_ID}`;
+const _DATABASE = `projects/${_PROJECT_ID}/instances/${_INSTANCE_ID}/databases/${_DATABASE_ID}`;
 const _TEST_SQL = `select id from ${_TABLE_NAME}`;
 const _CONFIG_FILE = `${__dirname}/spanner.grpc.config`;
 
@@ -78,12 +77,13 @@ describe('Using ' + grpcLibName, () => {
     console.log(`Waiting for operation on ${database.id} to complete...`);
     await dbOp.promise();
 
-    console.log(`Created database ${_DATABASE_ID} on instance ${_INSTANCE_ID}.`);
+    console.log(
+      `Created database ${_DATABASE_ID} on instance ${_INSTANCE_ID}.`
+    );
 
     // Create test table.
     const table = database.table(_TABLE_NAME);
-    const schema =
-        `CREATE TABLE ${_TABLE_NAME} (id STRING(1024)) PRIMARY KEY(id)`;
+    const schema = `CREATE TABLE ${_TABLE_NAME} (id STRING(1024)) PRIMARY KEY(id)`;
 
     const [, tableOp] = await table.create(schema);
     console.log(`Waiting for operation on ${table.id} to complete...`);
@@ -95,7 +95,7 @@ describe('Using ' + grpcLibName, () => {
       id: 'payload',
     };
 
-    console.log(`Inserting row to the table...`);
+    console.log('Inserting row to the table...');
     await table.insert(row);
     console.log(`Row inserted into table "${_TABLE_NAME}".`);
   });
@@ -294,14 +294,8 @@ describe('Using ' + grpcLibName, () => {
         Promise.all(createCallPromises)
           .then(
             results => {
-              assert.strictEqual(
-                pool.channelRefs.length,
-                expectedNumChannels
-              );
-              assert.strictEqual(
-                pool.channelRefs[0].affinityCount,
-                watermark
-              );
+              assert.strictEqual(pool.channelRefs.length, expectedNumChannels);
+              assert.strictEqual(pool.channelRefs[0].affinityCount, watermark);
               assert.strictEqual(
                 pool.channelRefs[0].activeStreamsCount,
                 watermark
@@ -334,10 +328,7 @@ describe('Using ' + grpcLibName, () => {
           )
           .then(
             () => {
-              assert.strictEqual(
-                pool.channelRefs.length,
-                expectedNumChannels
-              );
+              assert.strictEqual(pool.channelRefs.length, expectedNumChannels);
               assert.strictEqual(pool.channelRefs[0].affinityCount, 0);
               assert.strictEqual(pool.channelRefs[0].activeStreamsCount, 0);
               done();

--- a/test/unit/channel_factory_test.js
+++ b/test/unit/channel_factory_test.js
@@ -103,18 +103,148 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
 
         it('should build min channels', () => {
           const channel = new grpcGcp.GcpChannelFactory(
-              'hostname',
-              insecureCreds,
-              {
-                gcpApiConfig: grpcGcp.createGcpApiConfig({
-                  "channelPool": {
-                    "minSize": 3
-                  }
-                })
-              }
+            'hostname',
+            insecureCreds,
+            {
+              gcpApiConfig: grpcGcp.createGcpApiConfig({
+                channelPool: {
+                  minSize: 3,
+                },
+              }),
+            }
           );
           assert.equal(channel.channelRefs.length, 3);
-        })
+        });
+      });
+      describe('affinity bindings', () => {
+        let channelFactory;
+        let mockChannelRef;
+
+        beforeEach(() => {
+          channelFactory = new grpcGcp.GcpChannelFactory(
+            'hostname',
+            insecureCreds,
+            {}
+          );
+          mockChannelRef = channelFactory.getChannelRef();
+        });
+
+        afterEach(() => {
+          channelFactory.close();
+        });
+
+        describe('bindIfUnbound', () => {
+          it('should return true and increment affinityCount for a new key', () => {
+            const initialCount = mockChannelRef.getAffinityCount();
+            const result = channelFactory.bindIfUnbound(
+              mockChannelRef,
+              'txn-1'
+            );
+            assert.strictEqual(result, true);
+            assert.strictEqual(
+              mockChannelRef.getAffinityCount(),
+              initialCount + 1
+            );
+            assert.strictEqual(channelFactory.isBound('txn-1'), true);
+          });
+
+          it('should return false and not increment affinityCount if key is already bound', () => {
+            channelFactory.bindIfUnbound(mockChannelRef, 'txn-2');
+            const countAfterFirstBind = mockChannelRef.getAffinityCount();
+
+            // Try to bind the same key again
+            const result = channelFactory.bindIfUnbound(
+              mockChannelRef,
+              'txn-2'
+            );
+            assert.strictEqual(result, false);
+            assert.strictEqual(
+              mockChannelRef.getAffinityCount(),
+              countAfterFirstBind
+            );
+          });
+        });
+
+        describe('unbind', () => {
+          it('should immediately delete key if affinityCount hits zero', () => {
+            channelFactory.bindIfUnbound(mockChannelRef, 'txn-3');
+            assert.strictEqual(channelFactory.isBound('txn-3'), true);
+
+            channelFactory.unbind('txn-3');
+            assert.strictEqual(channelFactory.isBound('txn-3'), false);
+          });
+
+          it('should wait for affinityCount to hit zero before deleting key for legacy bind', () => {
+            // Legacy bind increments blindly
+            channelFactory.bind(mockChannelRef, 'txn-4');
+            channelFactory.bind(mockChannelRef, 'txn-4');
+
+            assert.strictEqual(channelFactory.isBound('txn-4'), true);
+
+            // First unbind
+            channelFactory.unbind('txn-4');
+            assert.strictEqual(channelFactory.isBound('txn-4'), true); // Still bound!
+
+            // Second unbind
+            channelFactory.unbind('txn-4');
+            assert.strictEqual(channelFactory.isBound('txn-4'), false); // Now deleted
+          });
+        });
+
+        describe('idle key cleanup', () => {
+          let originalDateNow;
+          beforeEach(() => {
+            originalDateNow = Date.now;
+          });
+          afterEach(() => {
+            Date.now = originalDateNow;
+          });
+
+          it('should cleanup idle keys after 3 minutes', () => {
+            const factory = new grpcGcp.GcpChannelFactory(
+              'hostname',
+              insecureCreds,
+              {}
+            );
+            Date.now = () => 1000; // Start at 1000ms
+            const ref = factory.getChannelRef();
+            factory.bindIfUnbound(ref, 'idle-key-1');
+            assert.strictEqual(factory.isBound('idle-key-1'), true);
+
+            // Advance time by slightly more than 3 minutes (180000ms)
+            Date.now = () => 1000 + 180001;
+
+            // Manually trigger the private cleanup method
+            factory.cleanupIdleKeys();
+
+            assert.strictEqual(factory.isBound('idle-key-1'), false);
+            factory.close();
+          });
+
+          it('should not cleanup keys that are accessed within 3 minutes', () => {
+            const factory = new grpcGcp.GcpChannelFactory(
+              'hostname',
+              insecureCreds,
+              {}
+            );
+            Date.now = () => 1000;
+            const ref = factory.getChannelRef();
+            factory.bindIfUnbound(ref, 'active-key-1');
+            assert.strictEqual(factory.isBound('active-key-1'), true);
+
+            // Advance time by 2 minutes and access it
+            Date.now = () => 1000 + 120000;
+            factory.getChannelRef('active-key-1'); // Updates lastAccessed
+
+            // Advance time by another 2 minutes (total 4 since bind, but 2 since last access)
+            Date.now = () => 1000 + 240000;
+            factory.cleanupIdleKeys();
+
+            // It should still be bound
+            assert.strictEqual(factory.isBound('active-key-1'), true);
+            factory.close();
+          });
+        });
       });
       describe('close', () => {
         let channel;

--- a/test/unit/channel_factory_test.js
+++ b/test/unit/channel_factory_test.js
@@ -244,6 +244,84 @@ for (const grpcLibName of ['grpc', '@grpc/grpc-js']) {
             assert.strictEqual(factory.isBound('active-key-1'), true);
             factory.close();
           });
+
+          it('should NOT cleanup regular session keys bound via bind', () => {
+            const factory = new grpcGcp.GcpChannelFactory(
+              'hostname',
+              insecureCreds,
+              {}
+            );
+            Date.now = () => 1000;
+            const ref = factory.getChannelRef();
+            factory.bind(ref, 'regular-session-key');
+            assert.strictEqual(factory.isBound('regular-session-key'), true);
+
+            // Advance time by slightly more than 3 minutes (180000ms)
+            Date.now = () => 1000 + 180001;
+
+            // Manually trigger the private cleanup method
+            factory.cleanupIdleKeys();
+
+            // It should still be bound because bind() ignores TTL tracking
+            assert.strictEqual(factory.isBound('regular-session-key'), true);
+            factory.close();
+          });
+
+          it('should correctly isolate cleanup when both custom and regular keys are present', () => {
+            const factory = new grpcGcp.GcpChannelFactory(
+              'hostname',
+              insecureCreds,
+              {}
+            );
+            Date.now = () => 1000;
+            const ref = factory.getChannelRef();
+
+            // Bind a custom transaction key
+            factory.bindIfUnbound(ref, 'custom-tx-key');
+            // Bind a regular session key
+            factory.bind(ref, 'regular-session-key');
+
+            assert.strictEqual(factory.isBound('custom-tx-key'), true);
+            assert.strictEqual(factory.isBound('regular-session-key'), true);
+
+            // Advance time by slightly more than 3 minutes (180000ms)
+            Date.now = () => 1000 + 180001;
+
+            // Mock getAffinityCount to 0 to bypass the legacy grpc-gcp-node
+            // bug where unbind doesn't delete keys if affinityCount > 0
+            ref.getAffinityCount = () => 0;
+            factory.cleanupIdleKeys();
+
+            // Custom key should be cleaned up, regular key should survive
+            assert.strictEqual(factory.isBound('custom-tx-key'), false);
+            assert.strictEqual(factory.isBound('regular-session-key'), true);
+            factory.close();
+          });
+
+          it('getChannelRef should not accidentally start a timer for regular session keys', () => {
+            const factory = new grpcGcp.GcpChannelFactory(
+              'hostname',
+              insecureCreds,
+              {}
+            );
+            Date.now = () => 1000;
+            const ref = factory.getChannelRef();
+
+            factory.bind(ref, 'regular-session-key');
+
+            // Advance time by 2 minutes and access it
+            Date.now = () => 1000 + 120000;
+            factory.getChannelRef('regular-session-key'); // Simulating network activity
+
+            // Advance time by another 2 minutes (total 4)
+            Date.now = () => 1000 + 240000;
+
+            factory.cleanupIdleKeys();
+
+            // It should still be bound because getChannelRef doesn't track keys missing from TTL map
+            assert.strictEqual(factory.isBound('regular-session-key'), true);
+            factory.close();
+          });
         });
       });
       describe('close', () => {


### PR DESCRIPTION
- This PR contains changes for handling support for custom affinity key changes

- The binding and unbinding logic for a custom affinity key

BEGIN_COMMIT_OVERRIDE
feat: Support for affinity key via call options
END_COMMIT_OVERRIDE